### PR TITLE
Don't duplicate `aeson-0.11.1.0`'s `Natural` instance

### DIFF
--- a/src/Data/Aeson/Compat.hs
+++ b/src/Data/Aeson/Compat.hs
@@ -221,6 +221,7 @@ instance ToJSON LocalTime where
 -- Instances in aeson-0.11
 -----------------------------------------------------------------------
 
+#if !(MIN_VERSION_aeson(0,11,1))
 #if !(MIN_VERSION_aeson(0,11,0) && MIN_VERSION_base(4,8,0))
 instance ToJSON Natural where
     toJSON = toJSON . toInteger
@@ -236,6 +237,7 @@ instance FromJSON Natural where
       if Scientific.coefficient s < 0
         then fail $ "Expected a Natural number but got the negative number: " ++ show s
         else pure $ truncate s
+#endif
 #endif
 
 #if !MIN_VERSION_aeson(0,11,0)


### PR DESCRIPTION
`aeson-0.11.0.0` made its `Natural` instances conditional on the base version. https://github.com/bos/aeson/blob/0.11.0.0/Data/Aeson/Types/Instances.hs#L356 So if you were using e.g. GHC 7.8 it wouldn't provide the `Natural` instances and it made sense for `aeson-compat` to provide them. 

`aeson-0.11.1.0` made these instances unconditional. https://github.com/bos/aeson/blob/0.11.1.0/Data/Aeson/Types/Instances.hs#L359 Consequently, if you're using `aeson-0.11.1.0` and GHC 7.8, `aeson-compat` defines a second instance and you end up with

```
src/Data/Aeson/Compat.hs:225:10:
    Duplicate instance declarations:
      instance ToJSON Natural
        -- Defined at src/Data/Aeson/Compat.hs:225:10
      instance [incoherent] ToJSON Natural
        -- Defined in `aeson-0.11.1.0:Data.Aeson.Types.Instances'

src/Data/Aeson/Compat.hs:234:10:
    Duplicate instance declarations:
      instance FromJSON Natural
        -- Defined at src/Data/Aeson/Compat.hs:234:10
      instance [incoherent] FromJSON Natural
        -- Defined in `aeson-0.11.1.0:Data.Aeson.Types.Instances'
cabal: Error: some packages failed to install:
```

This change fixes the duplicate instances by always omitting the `aeson-compat` instances if the `aeson` version is `0.11.1` or greater (regardless of `base` version).