### PR TITLE
Skip nats dependency on new versions of ghc.

### DIFF
--- a/aeson-compat.cabal
+++ b/aeson-compat.cabal
@@ -42,7 +42,6 @@ library
     , containers               >=0.5  && <0.6
     , exceptions               >=0.8  && <0.9
     , hashable                 >=1.2  && <1.3
-    , nats                     >=1 && <1.2
     , scientific               >=0.3  && <0.4
     , text                     >=1.2  && <1.3
     , time                     >=1.4.2 && <1.9
@@ -51,6 +50,8 @@ library
     , vector                   >=0.10 && <0.13
     , semigroups               >=0.16.2.2 && <0.19
     , tagged                   >=0.7.3 && <0.9
+  if impl(ghc < 7.10)
+    build-depends: nats        >=1 && <1.2
   exposed-modules:
       Data.Aeson.Compat
   default-language: Haskell2010
@@ -70,7 +71,6 @@ test-suite aeson-compat-test
     , containers
     , exceptions
     , hashable
-    , nats
     , scientific
     , text
     , time
@@ -86,4 +86,6 @@ test-suite aeson-compat-test
     , tasty-quickcheck      >=0.8  && <0.10
     , QuickCheck            >=2.10 && <2.11
     , quickcheck-instances  >=0.3.16  && <0.4
+  if impl(ghc < 7.10)
+    build-depends: nats
   default-language: Haskell2010


### PR DESCRIPTION
It is builtin there.