### PR TITLE
Bump bounds

### DIFF
--- a/aeson-compat.cabal
+++ b/aeson-compat.cabal
@@ -44,7 +44,7 @@ library
     , hashable                 >=1.2  && <1.3
     , scientific               >=0.3  && <0.4
     , text                     >=1.2  && <1.3
-    , time                     >=1.4.0.1 && <1.9
+    , time                     >=1.4.0.1 && <1.10
     , time-locale-compat       >=0.1.0.1 && <0.2
     , unordered-containers     >=0.2  && <0.3
     , vector                   >=0.10 && <0.13

--- a/aeson-compat.cabal
+++ b/aeson-compat.cabal
@@ -84,7 +84,7 @@ test-suite aeson-compat-test
     , vector
     , tagged
     , aeson-compat
-    , base-orphans          >=0.4.5 && <0.7
+    , base-orphans          >=0.4.5 && <0.8
     , tasty                 >=0.10 && <1.1
     , tasty-hunit           >=0.9  && <0.11
     , tasty-quickcheck      >=0.8  && <0.11

--- a/aeson-compat.cabal
+++ b/aeson-compat.cabal
@@ -40,7 +40,7 @@ library
     , attoparsec-iso8601       >=1.0.0.0 && <1.1
     , bytestring               >=0.10 && <0.11
     , containers               >=0.5  && <0.6
-    , exceptions               >=0.8  && <0.10
+    , exceptions               >=0.8  && <0.11
     , hashable                 >=1.2  && <1.3
     , scientific               >=0.3  && <0.4
     , text                     >=1.2  && <1.3


### PR DESCRIPTION
I want to use both aeson-compat and exceptions-0.10.0 in my project, so I need aeson-compat's version bounds to include exceptions-0.10.0. I also took the opportunity to bump all the other bounds to the latest version, where applicable. I made sure to compile with the new versions, not just with a `.cabal` file which accepts the new versions, and the tests still pass.