### PR TITLE
Allow aeson-2.1 and attoparsec-iso8601-1.1

### DIFF
--- a/aeson-compat.cabal
+++ b/aeson-compat.cabal
@@ -1,6 +1,6 @@
 name:               aeson-compat
 version:            0.3.10
-x-revision:         2
+x-revision:         3
 synopsis:           Compatibility layer for aeson
 description:        Compatibility layer for @aeson@
 category:           Web
@@ -37,9 +37,9 @@ library
   hs-source-dirs:   src
   ghc-options:      -Wall
   build-depends:
-      aeson                 >=0.7.0.6 && <1.6 || >=2.0.0.0 && <2.1
+      aeson                 >=0.7.0.6 && <1.6 || >=2.0.0.0 && <2.2
     , attoparsec            >=0.12    && <0.15
-    , attoparsec-iso8601    >=1.0.0.0 && <1.1
+    , attoparsec-iso8601    >=1.0.0.0 && <1.2
     , base                  >=4.6     && <4.17
     , base-compat           >=0.6.0   && <0.13
     , bytestring            >=0.10    && <0.12


### PR DESCRIPTION
Note, you might get whatever Day instances,
if you are not restricting the above dependencies.

This is tradeoff for compatibility price.