### PR TITLE
Fix compatibility with aeson-compat 2.1.2+

### DIFF
--- a/src/Data/Aeson/Compat.hs
+++ b/src/Data/Aeson/Compat.hs
@@ -167,11 +167,13 @@ import qualified Data.Aeson.KeyMap as KM
 
 import Data.Attoparsec.Number (Number (..))
 
+#if !MIN_VERSION_aeson(2,1,2)
 -- | Exception thrown by 'decode' - family of functions in this module.
 newtype AesonException = AesonException String
   deriving (Show, Typeable)
 
 instance Exception AesonException
+#endif
 
 eitherAesonExc :: (MonadThrow m) => Either String a -> m a
 eitherAesonExc (Left err) = throwM (AesonException err)


### PR DESCRIPTION
```
[1 of 1] Compiling Data.Aeson.Compat ( src/Data/Aeson/Compat.hs, dist/build/Data/Aeson/Compat.dyn_o )

src/Data/Aeson/Compat.hs:174:20: error:
    Ambiguous occurrence ‘AesonException’
    It could refer to
       either ‘Data.Aeson.AesonException’,
              imported from ‘Data.Aeson’ at src/Data/Aeson/Compat.hs:(100,1)-(111,3)
           or ‘Data.Aeson.Compat.AesonException’,
              defined at src/Data/Aeson/Compat.hs:171:1
    |
174 | instance Exception AesonException
    |                    ^^^^^^^^^^^^^^

src/Data/Aeson/Compat.hs:177:37: error:
    Ambiguous occurrence ‘AesonException’
    It could refer to
       either ‘Data.Aeson.AesonException’,
              imported from ‘Data.Aeson’ at src/Data/Aeson/Compat.hs:(100,1)-(111,3)
           or ‘Data.Aeson.Compat.AesonException’,
              defined at src/Data/Aeson/Compat.hs:171:26
    |
177 | eitherAesonExc (Left err) = throwM (AesonException err)
    |                                     ^^^^^^^^^^^^^^
```